### PR TITLE
Load configs from $_ENV

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -33,7 +33,7 @@ abstract class Config
 
     }
 
-    private function loadConfigFromFile($config_path){
+    private static function loadConfigFromFile($config_path){
       /**
        * @var array{
        *     oauth_app?: array{
@@ -61,7 +61,7 @@ abstract class Config
      * TODO: hopefully this entire class gets replaced by something like
      * https://github.com/vlucas/phpdotenv at some point.
      */
-    private function loadConfigFromEnv(){
+    private static function loadConfigFromEnv(){
 
       // initialize an empty config
       $config = array();
@@ -96,7 +96,7 @@ abstract class Config
 
     }
 
-    private function initializeConfig($config){
+    private static function initializeConfig($config){
       if (isset($config['custom']['personal_token'])) {
         return self::$config = new Config\Custom(
           $config['custom']['personal_token'],

--- a/src/Config.php
+++ b/src/Config.php
@@ -25,43 +25,98 @@ abstract class Config
         $config_path = __DIR__ . '/../config.json';
 
         if (!file_exists($config_path)) {
-            throw new \UnexpectedValueException('Missing config');
+          return self::loadConfigFromEnv();
+        } else {
+          return self::loadConfigFromFile($config_path);
         }
 
-        /**
-         * @var array{
-         *     oauth_app?: array{
-         *         client_id: string,
-         *         client_secret: string
-         *     },
-         *     custom?: array{
-         *         personal_token: string
-         *     },
-         *     host?: string,
-         *     mysql: array{dsn: string, user: string, password: string}
-         * }
-         */
-        $config = json_decode(file_get_contents($config_path), true);
 
-        if (isset($config['custom']['personal_token'])) {
-            return self::$config = new Config\Custom(
-                $config['custom']['personal_token'],
-                $config['custom']['webhook_secret'] ?? null,
-                $config['gh_enterprise_url'] ?? null,
-                $config['mysql']
-            );
+    }
+
+    private function loadConfigFromFile($config_path){
+      /**
+       * @var array{
+       *     oauth_app?: array{
+       *         client_id: string,
+       *         client_secret: string
+       *     },
+       *     custom?: array{
+       *         personal_token: string
+       *     },
+       *     host?: string,
+       *     mysql: array{dsn: string, user: string, password: string}
+       * }
+       */
+      $config = json_decode(file_get_contents($config_path), true);
+
+      return self::initializeConfig($config);
+
+    }
+    
+    /**
+     * This is a crazy method meant to pull SHEPHERD_ vars from $_ENV
+     * into a structure mirroring self::loadConfigFromFilie for use with
+     * self::initializeConfig
+     *
+     * TODO: hopefully this entire class gets replaced by something like
+     * https://github.com/vlucas/phpdotenv at some point.
+     */
+    private function loadConfigFromEnv(){
+
+      // initialize an empty config
+      $config = array();
+
+      // search each ENV
+      foreach ( $_ENV as $var_name => $val ){
+        // for shepherd vars
+        if ( strpos( $var_name, 'SHEPHERD' ) === 0 ){
+          $var_parts = explode( '_', $var_name, 2 );
+          // save the suffix, we'll need it later to tell if its a config group, or root level config item
+          $var_name_suffix = $var_parts[1];
+          // this var is either a config group, or root level item
+          $is_a_config_group = false;
+          // check the suffix to see if it begins with any of these config group names
+          foreach( ['CUSTOM', 'OAUTH_APP', 'MYSQL'] as $config_group ){
+            if( strpos( $var_name_suffix, $config_group ) === 0 ){
+              // remember that this var was a config group, so no need to set it as a root level item later
+              $is_a_config_group = true;
+              // set the item as a child of the config group in the $config structure initialized earlier
+              $config[ strtolower( $config_group ) ][ strtolower( substr( $var_name_suffix, strlen($config_group) + 1 ) ) ] = $val;
+            }
+          }
+          // if the item was not a config group item, set it as a root level item in $config
+          if( $is_a_config_group === false ){
+            $config[ strtolower( $var_name_suffix ) ] = $val;
+          }
         }
+      }
 
-        if (isset($config['oauth_app']['client_id']) && isset($config['oauth_app']['client_secret'])) {
-            return self::$config = new Config\OAuthApp(
-                $config['oauth_app']['client_id'],
-                $config['oauth_app']['client_secret'],
-                $config['gh_enterprise_url'] ?? null,
-                $config['oauth_app']['public_access_oauth_token'] ?? null,
-                $config['mysql']
-            );
-        }
+      // initialize the config with all the SHEPHERD_ vars we got from $_ENV
+      return self::initializeConfig($config);
 
-        throw new \UnexpectedValueException('Invalid config');
+    }
+
+    private function initializeConfig($config){
+      if (isset($config['custom']['personal_token'])) {
+        return self::$config = new Config\Custom(
+          $config['custom']['personal_token'],
+          $config['custom']['webhook_secret'] ?? null,
+          $config['gh_enterprise_url'] ?? null,
+          $config['mysql']
+        );
+      }
+
+      if (isset($config['oauth_app']['client_id']) && isset($config['oauth_app']['client_secret'])) {
+        return self::$config = new Config\OAuthApp(
+          $config['oauth_app']['client_id'],
+          $config['oauth_app']['client_secret'],
+          $config['gh_enterprise_url'] ?? null,
+          $config['oauth_app']['public_access_oauth_token'] ?? null,
+          $config['mysql']
+        );
+      }
+
+      throw new \UnexpectedValueException('Invalid config');
+
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -33,7 +33,8 @@ abstract class Config
 
     }
 
-    private static function loadConfigFromFile($config_path){
+    /** @return Config\Custom|Config\OAuthApp */
+    private static function loadConfigFromFile(String $config_path) {
       /**
        * @var array{
        *     oauth_app?: array{
@@ -60,8 +61,10 @@ abstract class Config
      *
      * TODO: hopefully this entire class gets replaced by something like
      * https://github.com/vlucas/phpdotenv at some point.
-     */
-    private static function loadConfigFromEnv(){
+     *
+     * @return Config\Custom|Config\OAuthApp
+     **/
+    private static function loadConfigFromEnv() {
 
       // initialize an empty config
       $config = array();
@@ -96,7 +99,8 @@ abstract class Config
 
     }
 
-    private static function initializeConfig($config){
+    /** @return Config\Custom|Config\OAuthApp */
+    private static function initializeConfig(Array $config) {
       if (isset($config['custom']['personal_token'])) {
         return self::$config = new Config\Custom(
           $config['custom']['personal_token'],


### PR DESCRIPTION
this pr updates the Config factory to load configs from environment variables if the config file does not exist. Note: there is no fallback mechanism in this iteration; either configs are loaded from the file, or env.
