### PR TITLE
setup travis to deploy to Docker hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,9 @@ script:
 # Base test matrix (php/env)
 matrix:
   fast_finish: true
+
+deploy:
+  provider: script
+  script: make deploy
+  on:
+    tags: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ COPY vendor /var/www/html/vendor
 COPY views /var/www/html/views
 COPY composer.* /var/www/html/
 COPY .htaccess /var/www/html
-COPY config.json /var/www/html
 COPY assets /var/www/html/assets
 
 RUN mkdir -p /var/www/html/database/github_commits && \

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+DOCKER_REPO=vimeo/shepherd
+DOCKER_TAG=$(TRAVIS_TAG)
+
 help: ## Prints this help
 	@grep -E '^([a-zA-Z0-9_-]|\%|\/)+:.*?## .*$$' Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {sub(/\%/, "<blah>", $$1)}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
@@ -38,5 +41,9 @@ dev-ssh: ## SSH into your current development environment
 	docker exec -it shepherd-php /bin/bash
 
 deploy:
-	docker build . -t $(name)
-	docker push $(name)
+	docker build . -t $(DOCKER_REPO):$(DOCKER_TAG)
+	echo "$(DOCKER_PASSWORD)" |  docker login -u "$(DOCKER_USERNAME)" --password-stdin
+	docker push $(DOCKER_REPO):$(DOCKER_TAG)
+	# optionally push this build as :latest tag as well
+	# docker tag $(DOCKER_REPO):$(DOCKER_TAG) $(DOCKER_REPO):latest
+	# docker push $(DOCKER_REPO):latest


### PR DESCRIPTION
this pr sets up Travis to deploy docker images to Docker hub (pending credentials being added to Travis).

The repo is set up on Docker hub here: https://hub.docker.com/repository/docker/vimeo/shepherd

Travis is set to build and deploy an image to Docker hub when a new tag is created. The docker image is tagged according to the Github tag.