### PR TITLE
Do not show unhandled exception output in browser

### DIFF
--- a/views/shields/coverage.php
+++ b/views/shields/coverage.php
@@ -5,11 +5,11 @@ require '../../vendor/autoload.php';
 $repository = $_SERVER['QUERY_STRING'];
 
 if (!preg_match('/^[-\d\w._]+\/[-\d\w._]+$/', $repository)) {
-	throw new \UnexpectedValueException('Repsitory format not recognised');
+	exit('Repository format not recognised');
 }
 
 if (strpos($repository, '..') !== false) {
-	throw new \UnexpectedValueException('Unexpected values in repository name');
+	exit('Unexpected values in repository name');
 }
 
 $pct = Psalm\Shepherd\Api::getTypeCoverage($repository);


### PR DESCRIPTION
Currently error e.g. like entering this URL: https://shepherd.dev/github/vimeo/psalm/coverage.svg?hello show this:

> Fatal error: Uncaught UnexpectedValueException: Repsitory format not recognised in /var/www/vhosts/shepherd.dev/httpdocs/views/shields/coverage.php:8 Stack trace: #0 {main} thrown in /var/www/vhosts/shepherd.dev/httpdocs/views/shields/coverage.php on line 8

Simple text with message should be enough for the user.