### PR TITLE
Allow custom label for type coverage badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ database/pr_comments/*.json
 database/pr_reviews/*.json
 database/psalm_data/*.json
 database/psalm_master_data/*.json
+views/shields/cache/*.svg
 config.json

--- a/.htaccess
+++ b/.htaccess
@@ -18,7 +18,7 @@ RewriteRule ^auth/github/configure$ views/auth/github_configure.php [L,QSA]
 
 RewriteRule ^reprocess/(.*)$ views/reprocess.php?sha=$1 [L,QSA]
 
-RewriteRule ^github/([-\d\w._]+\/[-\d\w._]+)/coverage.svg$ views/shields/coverage.php?$1 [L,QSA]
+RewriteRule ^github/([-\d\w._]+\/[-\d\w._]+)/coverage.svg$ views/shields/coverage.php?repository=$1 [L,QSA]
 RewriteRule ^github/([-\d\w._]+\/[-\d\w._]+)/coverage$ views/coverage_data.php?$1 [L,QSA]
 RewriteRule ^github/([-\d\w._]+\/[-\d\w._]+)/level.svg$ views/shields/level.php?$1 [L,QSA]
 RewriteRule ^github/([-\d\w._]+\/[-\d\w._]+)$ views/history.php?$1 [L,QSA]

--- a/views/shields/coverage.php
+++ b/views/shields/coverage.php
@@ -2,7 +2,8 @@
 
 require '../../vendor/autoload.php';
 
-$repository = $_SERVER['QUERY_STRING'];
+$label = $_GET['label'] ?? 'type-coverage';
+$repository = $_GET['repository'];
 
 if (!preg_match('/^[-\d\w._]+\/[-\d\w._]+$/', $repository)) {
     exit('Repository format not recognised');
@@ -18,13 +19,9 @@ header('Content-type: image/svg+xml;charset=utf-8');
 header('Cache-control: max-age=0, no-cache');
 
 if (!$pct) {
-    echo <<<SVG
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="150" height="20"><linearGradient id="b" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><clipPath id="a"><rect width="150" height="20" rx="3" fill="#fff"/></clipPath><g clip-path="url(#a)"><path fill="#555" d="M0 0h89v20H0z"/><path fill="#aaa" d="M89 0h61v20H89z"/><path fill="url(#b)" d="M0 0h150v20H0z"/></g><g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="optimizeLegibility" font-size="110"> <text x="455" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="790">type-coverage</text><text x="455" y="140" transform="scale(.1)" textLength="790">type-coverage</text><text x="1185" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="510">unknown</text><text x="1185" y="140" transform="scale(.1)" textLength="510">unknown</text></g> </svg>
-SVG;
-    exit;
-}
-
-if ($pct > 95) {
+    $pct = 'unknown';
+    $color = '#aaa';
+} elseif ($pct > 95) {
     $color = '#4c1';
 } elseif ($pct > 90) {
     $color = '#97ca00';
@@ -38,8 +35,23 @@ if ($pct > 95) {
     $color = '#e05d44';
 }
 
-$pct = $pct . '%';
+if ($pct !== 'unknown') {
+    $pct = $pct . '%';
+}
 
-echo <<<SVG
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="136" height="20"><linearGradient id="b" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><clipPath id="a"><rect width="136" height="20" rx="3" fill="#fff"/></clipPath><g clip-path="url(#a)"><path fill="#555" d="M0 0h89v20H0z"/><path fill="{$color}" d="M89 0h47v20H89z"/><path fill="url(#b)" d="M0 0h136v20H0z"/></g><g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="optimizeLegibility" font-size="110"> <text x="455" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="790">type-coverage</text><text x="455" y="140" transform="scale(.1)" textLength="790">type-coverage</text><text x="1115" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370">{$pct}</text><text x="1115" y="140" transform="scale(.1)" textLength="370">{$pct}</text></g> </svg>
-SVG;
+
+$cachedFile = __DIR__ . '/cache/' . md5($pct . $label) . '.svg';
+
+if (!file_exists($cachedFile)) {
+    file_put_contents(
+        $cachedFile,
+        file_get_contents(sprintf(
+            'https://img.shields.io/badge/%s-%s-%s',
+            $label,
+            urlencode($pct),
+            urlencode($color)
+        ))
+    );
+}
+
+readfile($cachedFile);


### PR DESCRIPTION
The idea is to allow using URL like `/github/vimeo/psalm/coverage.svg?label=Type%20coverage` to have custom label.

2 questions:
1. @muglug are you OK with this enhancement?
 
2. If so, any hint how to make it looking better?
 
The percentage already looks stretched:
![image](https://user-images.githubusercontent.com/9282069/113436855-c6fa0500-93e5-11eb-93b0-7b60981b1f90.png)

With short label (like "TC") it would be even more visible:
![image](https://user-images.githubusercontent.com/9282069/113436972-0e809100-93e6-11eb-8bca-635819ecb51d.png)

Is there the right way how to do it?
