### PR TITLE
Added timezone identifier to history

### DIFF
--- a/views/history.php
+++ b/views/history.php
@@ -69,7 +69,7 @@ $github_url = $config->gh_enterprise_url ?: 'https://github.com';
                 <tbody>
                     <?php foreach ($pct as $date => [$commit, $coverage, $total]) : ?>
                     <tr>
-                        <td><?php echo date('F j Y, H:i:s e', strtotime($date)) ?></td>
+                        <td><?php echo date('F j Y, H:i:s T', strtotime($date)) ?></td>
                         <td><a href="<?php echo $github_url . '/' . $repository . '/commit/' . $commit ?>"><?php echo substr($commit, 0, 7) ?></a></td>
                         <td><?php echo number_format($coverage, 3) ?>%</td>
                         <td><?php echo $formatLargeNummber($total) ?></td>
@@ -81,3 +81,4 @@ $github_url = $config->gh_enterprise_url ?: 'https://github.com';
     </div>
 </body>
 </html>
+


### PR DESCRIPTION
Without a timezone indication its rather hard to match the date of the history entry to a commit on github, since time is differen


![89ED528D-088C-41F5-A89D-5361327E0366](https://user-images.githubusercontent.com/120441/138593962-1538a98f-e14e-4964-8202-b23ffa3503eb.png)

![D387CF7B-4381-4DD2-AFCC-2BF1C7E19779](https://user-images.githubusercontent.com/120441/138593997-212b6331-cf4f-446d-a896-b48365d4b18e.png)
