### PR TITLE
Add a way to get psalm level data

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -21,6 +21,7 @@ RewriteRule ^reprocess/(.*)$ views/reprocess.php?sha=$1 [L,QSA]
 RewriteRule ^github/([-\d\w._]+\/[-\d\w._]+)/coverage.svg$ views/shields/coverage.php?$1 [L,QSA]
 RewriteRule ^github/([-\d\w._]+\/[-\d\w._]+)/coverage$ views/coverage_data.php?$1 [L,QSA]
 RewriteRule ^github/([-\d\w._]+\/[-\d\w._]+)/level.svg$ views/shields/level.php?$1 [L,QSA]
+RewriteRule ^github/([-\d\w._]+\/[-\d\w._]+)/level$ views/level_data.php?$1 [L,QSA]
 RewriteRule ^github/([-\d\w._]+\/[-\d\w._]+)$ views/history.php?$1 [L,QSA]
 RewriteRule ^psalm_open_issues$ views/psalm_open_issues.php [L,QSA]
 

--- a/views/level_data.php
+++ b/views/level_data.php
@@ -1,0 +1,53 @@
+<?php
+
+require '../vendor/autoload.php';
+
+$repository = $_SERVER['QUERY_STRING'];
+
+if (!preg_match('/^[-\d\w._]+\/[-\d\w._]+$/', $repository)) {
+    throw new UnexpectedValueException('Repsitory format not recognised');
+}
+
+if (strpos($repository, '..') !== false) {
+    throw new UnexpectedValueException('Unexpected values in repository name');
+}
+
+$level = Psalm\Shepherd\Api::getLevel($repository);
+
+header('Cache-control: max-age=0, no-cache');
+
+$data = [
+    'schemaVersion' => 1,
+    'label' => 'psalm-level',
+];
+
+if (!$level) {
+    $data += [
+        'message' => 'unknown',
+        'color' => '#aaa'
+    ];
+
+    echo json_encode($data);
+    exit;
+}
+
+if ($level === 1) {
+    $color = '#4c1';
+} elseif ($level === 2 || $level === 3) {
+    $color = '#97ca00';
+} elseif ($level === 4) {
+    $color = '#aeaf12';
+} elseif ($level === 5) {
+    $color = '#dfb317';
+} elseif ($level === 6) {
+    $color = '#fe7d37';
+} else {
+    $color = '#e05d44';
+}
+
+$data += [
+    'message' => $level,
+    'color' => $color,
+];
+
+echo json_encode($data);


### PR DESCRIPTION
Hi! Psalm is a great project and the shepherd page makes it super easy to visualize type coverage and psalm level with badges. We have a way to get the raw coverage data and display them using the shields.io badges, but there is no way to do the same with the psalm level.

This PR adds this endpoint.

Example level data URL: https://shepherd.dev/github/elephox-dev/framework/level
Example response:

```json
{
    "schemaVersion": 1,
    "label": "psalm-level",
    "message": "1",
    "color":"#4c1"
}
```