### PR TITLE
Fix invalid message property

### DIFF
--- a/views/level_data.php
+++ b/views/level_data.php
@@ -46,7 +46,7 @@ if ($level === 1) {
 }
 
 $data += [
-    'message' => $level,
+    'message' => (string)$level,
     'color' => $color,
 ];
 


### PR DESCRIPTION
Caused by #29.

Apparently, shields.io requires the type of the `message` property be string:

![image](https://user-images.githubusercontent.com/6266356/155626944-8aa94f34-ddd7-4d7a-9c12-e2d5d4f83426.png)

This PR should fix this.